### PR TITLE
Updating library for clojure 1.3.0

### DIFF
--- a/README
+++ b/README
@@ -39,7 +39,7 @@ The implementation borrows code from
 From git@github.com:ray1729/clj-message-digest.git for now, will make
 its way to Clojars RSN.
   
-## Changes For 1.3.0 Compatability
+## Changes For 1.3.0 Compatibility
 
 Removed clojure.contrib.io dependencies:
 * replaced *byte-array-type* with: (class (make-array Byte/TYPE 0))

--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 # clj-message-digest
 
-Message digest (MD5, SHA-1, etc.) functions for Clojure.
+Message digest (MD5, SHA-1, etc.) functions for Clojure 1.3.0
 
 For each digest algorithm supported by java.security.MessageDigest
 (MD2, MD5, SHA-1, SHA-256, SHA-384 and SHA-512), this namespace
@@ -39,6 +39,12 @@ The implementation borrows code from
 From git@github.com:ray1729/clj-message-digest.git for now, will make
 its way to Clojars RSN.
   
+## Changes For 1.3.0 Compatability
+
+Removed clojure.contrib.io dependencies:
+* replaced *byte-array-type* with: (class (make-array Byte/TYPE 0))
+* replaced to-byte-array with: (.getBytes s "UTF-8")
+* replaced input-stream with: clojure.java.io/input-stream
 ## License
 
 Copyright (C) 2011 Ray Miller <ray@1729.org.uk>

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,4 @@
 (defproject clj-message-digest "1.0.0-SNAPSHOT"
   :description "Message digest (MD5, SHA-1, etc.) functions for Clojure"
-  :dependencies [[org.clojure/clojure "1.2.1"]
-                 [org.clojure/clojure-contrib "1.2.0"]
+  :dependencies [[org.clojure/clojure "1.3.0"]
                  [commons-codec "1.5"]])

--- a/src/clj_message_digest/core.clj
+++ b/src/clj_message_digest/core.clj
@@ -1,5 +1,5 @@
 (ns clj-message-digest.core
-  (:use [clojure.contrib.io :only (to-byte-array input-stream *byte-array-type*)]
+  (:use [clojure.java.io :only (input-stream)]
         [clojure.string :only (lower-case)])
   (:import [java.security MessageDigest DigestInputStream]
            [java.io StringWriter InputStream File]
@@ -30,12 +30,12 @@
 
 (define-all-digests)
 
-(defmethod digest *byte-array-type* [algorithm b]
+(defmethod digest (class (make-array Byte/TYPE 0)) [algorithm b]
   (.. (java.security.MessageDigest/getInstance algorithm)
       (digest b)))
 
 (defmethod digest String [algorithm s]
-  (digest algorithm (to-byte-array s)))
+  (digest algorithm (.getBytes s "UTF-8")))
 
 (defmethod digest java.io.InputStream [algorithm stream]
   (let [message-digest (java.security.MessageDigest/getInstance algorithm)

--- a/test/clj_message_digest/test/core.clj
+++ b/test/clj_message_digest/test/core.clj
@@ -3,7 +3,7 @@
         [clojure.test])
   (:import [java.io File]))
 
-(declare tmpfile)
+(declare ^:dynamic tmpfile)
 
 (def test-string "foobar")
 (def expected-md5sum-hex "3858f62230ac3c915f300c664312c63f")


### PR DESCRIPTION
Adding comments into the README for what has changed.  Removed the dep on clojure.contrib.io
