### PR TITLE
Do not leak implicitly created input stream

### DIFF
--- a/src/clj_message_digest/core.clj
+++ b/src/clj_message_digest/core.clj
@@ -46,4 +46,5 @@
     (.digest message-digest)))
 
 (defmethod digest java.io.File [algorithm file]
-  (digest algorithm (input-stream file)))
+  (with-open [s (input-stream file)]
+    (digest algorithm s)))


### PR DESCRIPTION
The implementation leaks an implicitly created input stream when `digest` is called with a `File` argument.